### PR TITLE
Preserve time including seconds when date changed

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -470,6 +470,9 @@
                     if (self._d && opts.showTime) {
                         newDate.setHours(self._d.getHours());
                         newDate.setMinutes(self._d.getMinutes());
+                        if (opts.showSeconds) {
+                            newDate.setSeconds(self._d.getSeconds());
+                        }
                     }
                     self.setDate(newDate);
                     if (opts.bound) {


### PR DESCRIPTION
Previously only the hours and minutes were preserved when the date was changed. The seconds were reset to zero.